### PR TITLE
fix(ordering): improve backend ordering and use Map for frontend

### DIFF
--- a/backend/api/views/annotation_campaign.py
+++ b/backend/api/views/annotation_campaign.py
@@ -6,6 +6,7 @@ from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from django.db import transaction
 from django.db.models import Count, Q, Prefetch
+from django.db.models.functions import Lower
 
 from rest_framework import viewsets
 from rest_framework.response import Response
@@ -65,7 +66,7 @@ class AnnotationCampaignViewSet(viewsets.ViewSet):
                     to_attr="user_complete_tasks",
                 ),
             )
-            .order_by("name", "created_at")
+            .order_by(Lower("name"), "created_at")
         )
         if not request.user.is_staff:
             queryset = queryset.filter(annotators=request.user.id)
@@ -277,7 +278,7 @@ SPM Aural A 2010,sound038.wav,FINISHED,CREATED,CREATED,CREATED,CREATED""",
         header = ["dataset", "filename"]
         annotators = (
             campaign.annotators.distinct()
-            .order_by("username")
+            .order_by(Lower("username"))
             .values_list("username", flat=True)
         )
         data = [header + list(annotators)]
@@ -285,7 +286,9 @@ SPM Aural A 2010,sound038.wav,FINISHED,CREATED,CREATED,CREATED,CREATED""",
             campaign.tasks.select_related(
                 "dataset_file", "dataset_file__dataset", "annotator"
             )
-            .order_by("dataset_file__dataset__name", "dataset_file__filename")
+            .order_by(
+                Lower("dataset_file__dataset__name"), Lower("dataset_file__filename")
+            )
             .values_list(
                 "dataset_file__dataset__name",
                 "dataset_file__filename",

--- a/backend/api/views/annotation_set.py
+++ b/backend/api/views/annotation_set.py
@@ -1,5 +1,7 @@
 """Annotation set DRF-Viewset file"""
 
+from django.db.models.functions import Lower
+
 from rest_framework import viewsets
 from rest_framework.response import Response
 
@@ -16,6 +18,6 @@ class AnnotationSetViewSet(viewsets.ViewSet):
 
     def list(self, request):
         """List users"""
-        queryset = AnnotationSet.objects.all().order_by("name")
+        queryset = AnnotationSet.objects.all().order_by(Lower("name"))
         serializer = self.serializer_class(queryset, many=True)
         return Response(serializer.data)

--- a/backend/api/views/dataset.py
+++ b/backend/api/views/dataset.py
@@ -2,6 +2,7 @@
 import csv
 
 from django.db.models import Count
+from django.db.models.functions import Lower
 from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
 from django.conf import settings
 
@@ -30,7 +31,7 @@ class DatasetViewSet(viewsets.ViewSet):
         queryset = (
             Dataset.objects.annotate(Count("files"))
             .select_related("dataset_type")
-            .order_by("name", "created_at")
+            .order_by(Lower("name"), "created_at")
         )
 
         serializer = self.serializer_class(queryset, many=True)

--- a/backend/api/views/user.py
+++ b/backend/api/views/user.py
@@ -2,6 +2,7 @@
 
 from django.http import HttpResponse
 from django.db import IntegrityError
+from django.db.models.functions import Lower
 
 from rest_framework import viewsets, serializers
 from rest_framework.response import Response
@@ -22,7 +23,7 @@ class UserViewSet(viewsets.ViewSet):
 
     def list(self, request):
         """List users"""
-        queryset = User.objects.all().order_by("email")
+        queryset = User.objects.all().order_by(Lower("email"))
         serializer = self.serializer_class(queryset, many=True)
         return Response(serializer.data)
 

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -23,6 +23,7 @@
     }
   },
   "env": {
+    "es6": true,
     "node": true,
     "worker": true,
     "mocha": true,

--- a/frontend/src/CreateAnnotationCampaign.js
+++ b/frontend/src/CreateAnnotationCampaign.js
@@ -20,9 +20,7 @@ type annotation_set_type = {
 };
 
 type ShowAnnotationSetProps = {
-  annotation_sets: {
-    [?number]: annotation_set_type
-  },
+  annotation_sets: Map<number, annotation_set_type>,
   onChange: (event: SyntheticEvent<HTMLInputElement>) => void
 };
 
@@ -82,9 +80,7 @@ type confidence_indicator_set_type = {
 };
 
 type ShowConfidenceIndicatorSetProps = {
-  confidence_indicator_sets: {
-    [?number]: confidence_indicator_set_type
-  },
+  confidence_indicator_sets: Map<number, confidence_indicator_set_type>,
   onChange: (event: SyntheticEvent<HTMLInputElement>) => void
 };
 

--- a/frontend/src/ListChooser.js
+++ b/frontend/src/ListChooser.js
@@ -3,7 +3,11 @@
 import React, { Component } from 'react';
 
 export type choices_type = {
-  Map<number, {id: number, name: string}>
+  // Map<number, {id: number, name: string}>
+  [?number]: {
+    id: number,
+    name: string
+  }
 };
   
 type ListChooserProps = {

--- a/frontend/src/ListChooser.js
+++ b/frontend/src/ListChooser.js
@@ -1,7 +1,6 @@
 // @flow
 
 import React, { Component } from 'react';
-import * as utils from './utils';
 
 export type choices_type = {
   [?number]: {
@@ -20,7 +19,7 @@ type ListChooserProps = {
 
 class ListChooser extends Component<ListChooserProps> {
   render() {
-    let chosen_list = utils.objectValues(this.props.chosen_list).map(choice => {
+    let chosen_list = Array.from(this.props.chosen_list.values()).map(choice => {
       if (choice !== undefined) {
         return (
           <div className="col-sm-3 text-center border rounded" key={choice.id}>
@@ -33,8 +32,8 @@ class ListChooser extends Component<ListChooserProps> {
     });
 
     let select_choice;
-    if (Object.keys(this.props.choices_list).length > 0) {
-      let choices_list = utils.objectValues(this.props.choices_list).map(choice => {
+    if (this.props.choices_list.size > 0) {
+      let choices_list = Array.from(this.props.choices_list.values()).map(choice => {
         if (choice !== undefined) {
           return (
           <option key={choice.id} value={choice.id}>{choice.name}</option>

--- a/frontend/src/ListChooser.js
+++ b/frontend/src/ListChooser.js
@@ -3,10 +3,7 @@
 import React, { Component } from 'react';
 
 export type choices_type = {
-  [?number]: {
-    id: number,
-    name: string
-  }
+  Map<number, {id: number, name: string}>
 };
   
 type ListChooserProps = {

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -2,21 +2,12 @@
 
 // Utils functions
 
-export function arrayToObject(array: Array<any>, key: ?any = false) {
-  return array.reduce((obj, item, index) => {
-    if (key) {
-      obj[item[key]] = item
-    } else {
-      obj[index] = item
-    }
-
-    return obj
-  }, {});
-}
-
-// Object.values alternative for flow (cf https://github.com/facebook/flow/issues/2221)
-export function objectValues(obj: any): Array<any> {
-  return Object.keys(obj).map(key => obj[key]);
+export function arrayToMap(array: Array<any>, key: any) {
+  let res = new Map();
+  array.forEach((item) => {
+    res.set(item[key], item);
+  });
+  return res;
 }
 
 export function formatTimestamp(rawSeconds: number, withMs: ?boolean = true) {
@@ -47,20 +38,4 @@ export function buildTagColors(tags: Array<string>): Map<string, string> {
 export function getTagColor(tags: Map<string, string>, tag: string): string {
   const color: ?string = tags.get(tag);
   return color ? color : '#bbbbbb';
-}
-
-export function findObjetKey(objects, searchValue) {
-  for (const key in objects) {
-    if (objects[key].id === searchValue) {
-      return key
-    }
-  }
-}
-
-export function findObjetById(objects, searchValue) {
-  for (const key in objects) {
-    if (objects[key].id === searchValue) {
-      return objects[key]
-    }
-  }
 }

--- a/frontend/test/ListChooser.test.js
+++ b/frontend/test/ListChooser.test.js
@@ -8,15 +8,15 @@ describe('testing ListChooser component', function () {
     this.timeout(20000);
 
     it('mounts properly with correct selections', () => {
-        let choices_list = [
-            { id: 2, name: 'B' },
-            { id: 3, name: 'C' },
-            { id: 4, name: 'D' }
-        ];
-        let chosen_list = [
-            { id: 1, name: 'A' },
-            { id: 5, name: 'E' }
-        ];
+        let choices_list = new Map([
+            [2, { id: 2, name: 'B' }],
+            [3, { id: 3, name: 'C' }],
+            [4, { id: 4, name: 'D' }]
+        ]);
+        let chosen_list = new Map([
+            [1, { id: 1, name: 'A' }],
+            [5, { id: 5, name: 'E' }]
+        ]);
         let onSelectChange = () => null;
         let onDelClick = () => null;
         let wrapper = mount(


### PR DESCRIPTION
This should keep our ordering upgrade and repair campaign edition (as well as keep all the improvements to creation).

Well no the only thing that isn't kept is that initially your annotators list is the backend order (alphabetical order) however if you add some and then remove them : they are shown in the list in the ordered they have been removed. I believe the gain in code maintainability outweighs this "functionality" : the most important thing is that the initial list is in alphabetical order.

This PR can also be reviewed by doing a git diff on the changed files with commit "f1bac2f - feat(backend) : add created_at to dataset and campaign (#131) (Qouagga 2023-11-20 14:39:00)" that was just before the commit that added the original flawed ordering code. For example `git diff f1bac2f -- frontend/src/CreateAnnotationCampaign.js`.