### PR TITLE
fix(annotator): Play/pause audio button doesn't reset (#72)

### DIFF
--- a/frontend/src/AudioAnnotator/AudioAnnotator.js
+++ b/frontend/src/AudioAnnotator/AudioAnnotator.js
@@ -402,7 +402,6 @@ class AudioAnnotator extends Component<AudioAnnotatorProps, AudioAnnotatorState>
     this.audioPlayer.audioElement.play();
 
     this.setState({
-      isPlaying: true,
       stopTime: annotation ? annotation.endTime : undefined,
     });
   }
@@ -411,7 +410,6 @@ class AudioAnnotator extends Component<AudioAnnotatorProps, AudioAnnotatorState>
     this.audioPlayer.audioElement.pause();
 
     this.setState({
-      isPlaying: false,
       stopTime: undefined,
     });
   }
@@ -784,6 +782,8 @@ class AudioAnnotator extends Component<AudioAnnotatorProps, AudioAnnotatorState>
             ref={(element) => { if (element) this.audioPlayer = element; } }
             playbackRate={this.state.playbackRate}
             src={task.audioUrl}
+            onPause={() => this.setState({isPlaying: false})}
+            onPlay={() => this.setState({isPlaying: true})}
           ></AudioPlayer>
 
           {/* Workbench (spectrogram viz, box drawing) */}

--- a/frontend/src/AudioAnnotator/AudioAnnotator.js
+++ b/frontend/src/AudioAnnotator/AudioAnnotator.js
@@ -783,6 +783,7 @@ class AudioAnnotator extends Component<AudioAnnotatorProps, AudioAnnotatorState>
             playbackRate={this.state.playbackRate}
             src={task.audioUrl}
             onPause={() => this.setState({isPlaying: false})}
+            onAbort={() => this.setState({isPlaying: false})}
             onPlay={() => this.setState({isPlaying: true})}
           ></AudioPlayer>
 


### PR DESCRIPTION
Fixes #72 

Play/Pause btn wasn't resetting when the audio reached the end of the file.

To test: play en audio and let it reach the end. The button should come back at the "play button" state
Same when switch from annotation file during an audio play