### PR TITLE
fix(routing): Accessing direct child page ends up in 404

### DIFF
--- a/backend/start.sh
+++ b/backend/start.sh
@@ -1,17 +1,11 @@
 #!/bin/bash
 
 # If on staging we want some dev libraries like Faker for seeding
-if [ "$STAGING" = "true" ]
-then
-  echo ">>> Installing dev libraries"
-  poetry install
-fi
+if [ "$STAGING" = "true" ]; then poetry install; fi
 
 # Normal setup commands
-echo ">>> Setup"
 #poetry run python manage.py collectstatic --noinput # Since osmose.ifremer.fr is read-only, this won't work
 poetry run python manage.py migrate
 
 # Launching server
-echo ">>> Launching server"
 poetry run gunicorn -b 0.0.0.0:8000 backend.wsgi

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
 # If on staging we want some dev libraries like Faker for seeding
-if [ "$STAGING" = "true" ]; then poetry install; fi
+if [ "$STAGING" = "true" ]
+then
+  echo ">>> Installing dev libraries"
+  poetry install
+fi
 
 # Normal setup commands
+echo ">>> Setup"
 #poetry run python manage.py collectstatic --noinput # Since osmose.ifremer.fr is read-only, this won't work
 poetry run python manage.py migrate
 
 # Launching server
+echo ">>> Launching server"
 poetry run gunicorn -b 0.0.0.0:8000 backend.wsgi

--- a/dockerfiles/nginx.conf.template
+++ b/dockerfiles/nginx.conf.template
@@ -1,4 +1,3 @@
-# See https://tonny.medium.com/how-to-use-nginx-to-service-multiple-react-apps-641501e92581
 map $http_referer $webroot {
     "~/app" "/usr/share/nginx/app";
     "~/"    "/usr/share/nginx/website";

--- a/dockerfiles/nginx.conf.template
+++ b/dockerfiles/nginx.conf.template
@@ -10,10 +10,14 @@ server {
 
   location /app {
     root /usr/share/nginx/;
+    proxy_intercept_errors on;
+    error_page 404 = /app/index.html;
   }
 
   location / {
     root /usr/share/nginx/website/;
+    proxy_intercept_errors on;
+    error_page 404 = /index.html;
   }
 
   location /static {

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -31,19 +31,19 @@ const App: React.FC = () => {
         </Route>
         */}
 
-        <Route path="/people">
+        <Route exact path="/people">
           <Layout>
             <People />
           </Layout>
         </Route>
 
-        <Route path="/projects">
+        <Route exact path="/projects">
           <Layout>
             <Projects />
           </Layout>
         </Route>
 
-        <Route path="/publications">
+        <Route exact path="/publications">
           <Layout>
             <Publications />
           </Layout>
@@ -74,6 +74,10 @@ const App: React.FC = () => {
             <Ontology />
           </Layout>
         </Route> */}
+
+        <Route path="*">
+          <Redirect to="/"></Redirect>
+        </Route>
 
       </Switch>
     </Router>


### PR DESCRIPTION
Test:
- [ ] Check that loading a child route of website directly loads the page (no 404) ; eg: /news/1
- [ ] Check that loading a child route of frontend (APLOSE) directly loads the page (no 404) ; eg: /app/audio-annotator/365
- [ ] Request to unexisting api element ends in a 404 (server side) ; eg: /api/news/999