### PR TITLE
fix(result csv): cannot download result csv for campaign without confidence set

### DIFF
--- a/backend/api/views/annotation_campaign.py
+++ b/backend/api/views/annotation_campaign.py
@@ -179,8 +179,8 @@ SPM Aural B,sound000.wav,284.0,493.0,5794.0,8359.0,Boat,Albert,2012-05-03T11:10:
 
         for result in results:
             confidence_indicator_and_lvl_max = ""
-            max_level = campaign.confidence_indicator_set.max_level
             if campaign.confidence_indicator_set is not None:
+                max_level = campaign.confidence_indicator_set.max_level
                 confidence_indicator_and_lvl_max = (
                     f"{result.confidence_indicator.level}/{max_level}"
                 )


### PR DESCRIPTION
fixes #163 

Test: create a campaign without confidence set and set some annotations, then download the results csv