### PR TITLE
adding the cff file with zenodo doi

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,14 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "Keribin"
+  given-names: "Erwan"
+- family-names: "Morin"
+  given-names: "Élodie"
+- family-names: "Vovard"
+  given-names: "Romain"
+title: "APLOSE: a scalable web-based annotation tool for marine bioacoustics - public repository"
+version: 1.6.4
+doi: 10.5281/zenodo.10468000
+date-released: 2024-01-08
+url: "https://github.com/Project-OSmOSE/osmose-app"


### PR DESCRIPTION
Adding a CFF file (yaml format) to ease the citation of the repository (given the GitHub support for these files, this should add a "cite this repository" button on the main page, see the [GitHub documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files)). The DOI was generated by linking the repository to Zenodo.