### PR TITLE
fix(metadatax): Module not found

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osmose",
-  "version": "1.11.6",
+  "version": "1.11.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "osmose",
-      "version": "1.11.6",
+      "version": "1.11.7",
       "devDependencies": {
         "concurrently": "^8.2.2"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osmose",
-  "version": "1.11.6",
+  "version": "1.11.7",
   "scripts": {
     "database:remove": "docker stop devdb && docker rm devdb",
     "database:create": "docker run --name osmose_dev_db -e POSTGRES_PASSWORD=postgres -p 127.0.0.1:5432:5432 -d postgis/postgis",

--- a/website/src/pages/Projects/ProjectDetail/ProjectDetail.tsx
+++ b/website/src/pages/Projects/ProjectDetail/ProjectDetail.tsx
@@ -7,7 +7,7 @@ import { ContactList } from "../../../components/ContactList/ContactList";
 import { HTMLContent } from "../../../components/HTMLContent/HTMLContent";
 import { Back } from "../../../components/Back/Back";
 import { DeploymentsMap } from "../../../components/DeploymentsMap";
-import { DeploymentAPI, DeploymentService } from "@PAM-Standardization/metadatax-ts";
+import { DeploymentAPI, DeploymentService } from "@pam-standardization/metadatax-ts";
 import { DeploymentsTimeline } from "../../../components/DeploymentsTimeline";
 import './ProjectDetail.css';
 

--- a/website/src/pages/Projects/Projects.tsx
+++ b/website/src/pages/Projects/Projects.tsx
@@ -11,7 +11,7 @@ import { Project } from "../../models/project";
 import { IonCard, IonCardContent, IonCardHeader, IonCardSubtitle, IonCardTitle } from "@ionic/react";
 import { Pagination } from "../../components/Pagination/Pagination";
 import { DeploymentsMap } from "../../components/DeploymentsMap";
-import { DeploymentAPI, DeploymentService } from "@PAM-Standardization/metadatax-ts";
+import { DeploymentAPI, DeploymentService } from "@pam-standardization/metadatax-ts";
 
 
 export const Projects: React.FC = () => {


### PR DESCRIPTION
When building front, an error is raised preventing the correct deployment:
`Module not found: Error: Can't resolve '@PAM-Standardization/metadatax-ts' in '/opt/src/pages/Projects'`